### PR TITLE
#234 Use model name when project is stored directly on root git repository

### DIFF
--- a/plugins/org.eclipse.emf.diffmerge.sirius/src/org/eclipse/emf/diffmerge/sirius/SiriusImageHelper.java
+++ b/plugins/org.eclipse.emf.diffmerge.sirius/src/org/eclipse/emf/diffmerge/sirius/SiriusImageHelper.java
@@ -173,13 +173,18 @@ public class SiriusImageHelper {
    * @apiNote this api suppose that the given resource is directly located in it's root project. 
    *          (which is the case in caller methods)
    * @implNote URI can be from platform:/resource, commit:/ or other protocol such as cdo:/
+   *          on normal cases, the model uri contains the project name, but if the project is stored
+   *          on a root git repository, we retrieve the model name
    */
   protected String getProjectFromUri(URI uri_p) {
-    try {
+    if (uri_p.segmentCount() > 1) {
       return uri_p.segment(uri_p.segmentCount() - 2);
-    } catch (IndexOutOfBoundsException e) {
-      return null;
+      
+    } else if (uri_p.segmentCount() > 0) {
+      return uri_p.trimFileExtension().segment(uri_p.segmentCount() - 1);
     }
+    
+    return null;
   }
   
   /**

--- a/tests/org.eclipse.emf.diffmerge.tests.ju/src/org/eclipse/emf/diffmerge/tests/ju/SiriusScopeMethodTest.java
+++ b/tests/org.eclipse.emf.diffmerge.tests.ju/src/org/eclipse/emf/diffmerge/tests/ju/SiriusScopeMethodTest.java
@@ -68,6 +68,12 @@ public class SiriusScopeMethodTest {
     assertTrue(helper.getProjectFromUri(URI.createURI("any:/projectm/project/model.aird")).equals("project"));
   }
 
+  @Test
+  public void projectOnRootGit() {
+    SiriusHelper helper = new SiriusHelper();
+    assertTrue(helper.getProjectFromUri(URI.createURI("commit:/model.aird")).equals("model"));
+  }
+
   private class SiriusHelper extends SiriusImageHelper {
     
     public String getProjectFromUri(URI uri_p) {


### PR DESCRIPTION
Change-Id: Ie0eb3c2f9c97c9c151050017b6ca11f721f2f093
Signed-off-by: Philippe DUL <philippe.dul@thalesgroup.com>