### PR TITLE
#234 Return correct project name on models under remote repository

### DIFF
--- a/plugins/org.eclipse.emf.diffmerge.sirius/src/org/eclipse/emf/diffmerge/sirius/SiriusImageHelper.java
+++ b/plugins/org.eclipse.emf.diffmerge.sirius/src/org/eclipse/emf/diffmerge/sirius/SiriusImageHelper.java
@@ -175,21 +175,29 @@ public class SiriusImageHelper {
   /**
    * For a given resource URI, retrieve the root segment describing the root project name
    * 
-   * @apiNote this api suppose that the given resource is directly located in it's root project. 
-   *          (which is the case in caller methods)
-   * @implNote URI can be from platform:/resource, commit:/ or other protocol such as cdo:/
+   * @implNote URI can be from platform:/resource, commit:/ local:/ remote:/ or other protocol such as cdo:/
    *          on normal cases, the model uri contains the project name, but if the project is stored
    *          on a root git repository, we retrieve the model name
    */
   protected String getProjectFromUri(URI uri_p) {
-    if (uri_p.segmentCount() > 1) {
-      return uri_p.segment(uri_p.segmentCount() - 2);
+    String projectName = null;
+    
+    if (uri_p.isPlatformResource()) { 
+      projectName = uri_p.segment(1);
       
-    } else if (uri_p.segmentCount() > 0) {
-      return uri_p.trimFileExtension().segment(uri_p.segmentCount() - 1);
+    } else if ("cdo".equals(uri_p.scheme())) { //$NON-NLS-1$
+      projectName = uri_p.segment(0);
+      
+    } else if (uri_p.segmentCount() > 1) {
+      projectName = uri_p.segment(uri_p.segmentCount() - 2);
+      
+    } else if (uri_p.segmentCount() == 1) {
+      // When the project is directly stored under git, we cannot retrieve a project name as there is none
+      projectName = uri_p.trimFileExtension().segment(uri_p.segmentCount() - 1);
+      
     }
     
-    return null;
+    return projectName;
   }
   
   /**

--- a/tests/org.eclipse.emf.diffmerge.tests.ju/src/org/eclipse/emf/diffmerge/tests/ju/SiriusScopeMethodTest.java
+++ b/tests/org.eclipse.emf.diffmerge.tests.ju/src/org/eclipse/emf/diffmerge/tests/ju/SiriusScopeMethodTest.java
@@ -25,10 +25,10 @@ public class SiriusScopeMethodTest {
 
   @Test
   public void projectForAllElements() {
-    XMIResourceImpl mainResource = new XMIResourceImpl(URI.createPlatformResourceURI("root/a/a.elements", true));
+    XMIResourceImpl mainResource = new XMIResourceImpl(URI.createPlatformResourceURI("a/a.elements", true));
     Element element = ElementsFactory.eINSTANCE.createElement();
     
-    XMIResourceImpl childResource = new XMIResourceImpl(URI.createPlatformResourceURI("root/a/subfolder/b.elements", true));
+    XMIResourceImpl childResource = new XMIResourceImpl(URI.createPlatformResourceURI("a/subfolder/b.elements", true));
     Element element2 = ElementsFactory.eINSTANCE.createElement();
 
     mainResource.getContents().add(element);
@@ -42,10 +42,10 @@ public class SiriusScopeMethodTest {
 
   @Test
   public void projectForSeveralResources() {
-    XMIResourceImpl aResource = new XMIResourceImpl(URI.createPlatformResourceURI("root/a/a.elements", true));
+    XMIResourceImpl aResource = new XMIResourceImpl(URI.createPlatformResourceURI("a/a.elements", true));
     Element element = ElementsFactory.eINSTANCE.createElement();
     
-    XMIResourceImpl bResource = new XMIResourceImpl(URI.createPlatformResourceURI("root/b/b.elements", true));
+    XMIResourceImpl bResource = new XMIResourceImpl(URI.createPlatformResourceURI("b/b.elements", true));
     Element element2 = ElementsFactory.eINSTANCE.createElement();
     Element element3 = ElementsFactory.eINSTANCE.createElement();
 
@@ -59,19 +59,32 @@ public class SiriusScopeMethodTest {
     assertTrue("The project of an child element is the parent folder of its root container", helper.getMainProjectName(element2).equals("a"));
     assertTrue("The project of a root element is it's parent folder", helper.getMainProjectName(element3).equals("b"));
   }
+
+  @Test
+  public void projectPlatformResource() {
+    SiriusHelper helper = new SiriusHelper();
+
+    assertTrue(helper.getProjectFromUri(URI.createURI("platform:/resource/project/model.aird")).equals("project"));
+    assertTrue(helper.getProjectFromUri(URI.createURI("platform:/resource/project/fragments/model.airdfragments")).equals("project"));
+  }
+  
+  @Test
+  public void projectRemoteSirius() {
+    SiriusHelper helper = new SiriusHelper();
+    
+    assertTrue(helper.getProjectFromUri(URI.createURI("cdo://repository/project/model.aird")).equals("project"));
+    assertTrue(helper.getProjectFromUri(URI.createURI("cdo://repository/project/.representations/model.srm")).equals("project"));
+    assertTrue(helper.getProjectFromUri(URI.createURI("cdo://repository/project/fragments/model.airdfragment")).equals("project"));
+    
+  }
   
   @Test
   public void projectByProtocol() {
     SiriusHelper helper = new SiriusHelper();
     assertTrue(helper.getProjectFromUri(URI.createURI("commit:/root/sub/project/model.aird")).equals("project"));
-    assertTrue(helper.getProjectFromUri(URI.createURI("platform:/resource/project/model.aird")).equals("project"));
-    assertTrue(helper.getProjectFromUri(URI.createURI("any:/projectm/project/model.aird")).equals("project"));
-  }
-
-  @Test
-  public void projectOnRootGit() {
-    SiriusHelper helper = new SiriusHelper();
     assertTrue(helper.getProjectFromUri(URI.createURI("commit:/model.aird")).equals("model"));
+
+    assertTrue(helper.getProjectFromUri(URI.createURI("any:/projectm/project/model.aird")).equals("project"));
   }
 
   private class SiriusHelper extends SiriusImageHelper {


### PR DESCRIPTION
Change-Id: Ib3f5223aea307afdbc9efde1b7282f872b797c4c
Signed-off-by: Philippe DUL <philippe.dul@thalesgroup.com>