### PR TITLE
#263 Image cdo path with spaces are not properly transformed

### DIFF
--- a/plugins/org.eclipse.emf.diffmerge.sirius/src/org/eclipse/emf/diffmerge/sirius/SiriusImageHelper.java
+++ b/plugins/org.eclipse.emf.diffmerge.sirius/src/org/eclipse/emf/diffmerge/sirius/SiriusImageHelper.java
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2022 Thales Global Services S.A.S.
+ * Copyright (c) 2022, 2023 Thales Global Services S.A.S.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -118,6 +118,10 @@ public class SiriusImageHelper {
     if (projectName == null) {
       return value_p;
     }
+    // the cdo path is always encoded so it is needed to encode the project name
+    if (value_p.contains("src=\"cdo:/")) { //$NON-NLS-1$
+      projectName = URI.encodeFragment(projectName, true);
+    }
     return value_p.replaceAll("src=\"(cdo:/)?" + projectName + "/", "src=\"$1./"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
   }
 
@@ -133,6 +137,11 @@ public class SiriusImageHelper {
     String projectName = getMainProjectName(source_p);
     if (projectName == null) {
       return value_p;
+    }
+
+    // the cdo path is always encoded so it is needed to encode the project name
+    if (value_p.contains("src=\"cdo:/")) { //$NON-NLS-1$
+      projectName = URI.encodeFragment(projectName, true);
     }
     return value_p.replaceAll("src=\"(cdo:/)?\\./", "src=\"$1" + projectName + "/"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
   }
@@ -153,6 +162,11 @@ public class SiriusImageHelper {
     if (projectName == null) {
       return value_p;
     }
+    // the cdo path is always encoded so it is needed to encode the project name
+    if (value_p.startsWith("cdo:/")) { //$NON-NLS-1$
+      projectName = URI.encodeFragment(projectName, true);
+    }
+
     return value_p.replaceAll("^(cdo:/)?" + projectName + "/", "$1./"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
   }
 
@@ -170,14 +184,20 @@ public class SiriusImageHelper {
     if (projectName == null) {
       return value_p;
     }
+    // the cdo path is always encoded so it is needed to encode the project name
+    if (value_p.startsWith("cdo:/")) { //$NON-NLS-1$
+      projectName = URI.encodeFragment(projectName, true);
+    }
     return value_p.replaceAll("^(cdo:/)?\\./", "$1" + projectName + "/"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
   }
 
   /**
-   * For a given object, retrieve its project
+   * For a given object, retrieve its project.<br/>
+   * The name is always decode.
    * 
-   * @implSpec Note that the project name containing the element source_p might be different than the IProject containing the
-   *           Sirius session. Here we lookup for the project name owning the resource containing the element
+   * @implSpec Note that the project name containing the element source_p might be different than the IProject
+   *           containing the Sirius session. Here we lookup for the project name owning the resource containing the
+   *           element
    */
   protected String getProjectName(EObject source_p) {
     EObject root = EcoreUtil.getRootContainer(source_p, true);

--- a/plugins/org.eclipse.emf.diffmerge.sirius/src/org/eclipse/emf/diffmerge/sirius/SiriusScope.java
+++ b/plugins/org.eclipse.emf.diffmerge.sirius/src/org/eclipse/emf/diffmerge/sirius/SiriusScope.java
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2006-2019 Thales Global Services S.A.S.
+ * Copyright (c) 2006-2023 Thales Global Services S.A.S.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -81,7 +81,7 @@ public class SiriusScope extends GMFScope {
       new HashMap<String, DRepresentationDescriptor>();
   
   /** An helper for image helpers */
-  private SiriusImageHelper siriusImageHelper;
+  private SiriusImageHelper siriusImageHelper = new SiriusImageHelper();
   
   /**
    * Constructor


### PR DESCRIPTION
The project name stored in description and workspace path are decoded, but the cdo path are encoded so it is needed to encode the project name to transform the cdo path.

In addition,
org.eclipse.emf.diffmerge.sirius.SiriusScope.siriusImageHelper is initialized to better test SiriusScope independently of the editor that uses IComparison.

Bug: https://github.com/eclipse/org.eclipse.emf.diffmerge.core/issues/263